### PR TITLE
feat(tui): support Shift+arrow for card moves

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This project is intentionally minimal and opinionated.
 ## Features
 - Keyboard-first Kanban board
 - Columns and cards loaded from disk (no hardcoded data)
-- One-keystroke transitions (`H` / `L`)
+- One-keystroke transitions (`H` / `L` or Shift+←/→)
 - Toggle issue description (`Enter`)
 - `hjkl` **and** arrow-key navigation
 - Clean, terminal-native visuals
@@ -78,7 +78,7 @@ This format is:
 ## Keybindings
 - `h` / `l` **or** `←` / `→` — focus column
 - `j` / `k` **or** `↑` / `↓` — select card
-- `H` / `L` — move card left / right
+- `H` / `L` or Shift+←/→ — move card left / right
 - `Enter` — toggle description
 - `r` — reload board from disk
 - `Esc` — close description / quit


### PR DESCRIPTION
This pull request improves keyboard accessibility by allowing users to move cards left or right using Shift+←/→ in addition to the existing `H`/`L` shortcuts. The documentation and help text are updated to reflect this new keybinding, and the main event handling logic is modified to detect Shift+arrow key presses.

### Keyboard navigation improvements

* Added support for moving cards left/right using Shift+←/→ in addition to `H`/`L` by updating the key event handler to recognize Shift+arrow key combinations.
* Updated the action dispatch logic to pass the full `KeyEvent` (including modifiers) rather than just the key code, enabling detection of Shift key presses. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL24-R36) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL114-R122)

### Documentation updates

* Updated the `README.md` features and keybindings sections to mention Shift+←/→ as an alternative for moving cards left/right. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R18) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L81-R81)
* Updated the in-app help text to include the new Shift+←/→ shortcut for moving cards.

### Dependency and import adjustments

* Imported `KeyEvent` and `KeyModifiers` from `crossterm` to support handling of modifier keys.